### PR TITLE
解决构建失败问题。  update by liuzhennan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM ring2016/centos6-jdk7-maven3
 
 ### Compile ###
 ADD pom.xml /pom.xml
-RUN cd / && mvn dependency:go-offline
+RUN cd / && mvn  -Dhttps.protocols=TLSv1.2 dependency:go-offline
 
 WORKDIR /code
 ADD pom.xml /code/pom.xml
 ADD src /code/src
 ADD server.xml /usr/local/tomcat6/conf/server.xml
-RUN ["mvn", "package"]
+RUN ["mvn", "-Dhttps.protocols=TLSv1.2","package"]
 
 ### install ###
 RUN cp target/demo.war $CATALINA_HOME/webapps/


### PR DESCRIPTION
Sonatype no longer supports TLSv1.1 and below (effective, June 18th, 2018). My guess is that you are using TLSv1.1 protocol or below.

The documentation I listed gives you 4 options:

Upgrade your Java runtime, for example with OpenJDK builds or Oracle paying support
Configure your Java runtime to enable TLS 1.2 by **adding -Dhttps.protocols=TLSv1.2**
Use a repository manager that uses a Java version supporting TLS 1.2
Revert back to http until you can acheive one of the above remediation steps.
I fixed it myself by just using -Dhttps.protocols=TLSv1.2 as a VM argument